### PR TITLE
fix extraneous orb in TDM rewards at level 25

### DIFF
--- a/src/data/rewardsTDM.json
+++ b/src/data/rewardsTDM.json
@@ -54,10 +54,7 @@
     [1, "Orb"],
     [1, "Uncommon Depth CS", "Nomad Outpost"]
   ],
-  [
-    [1, "Orb"],
-    [1, "Common Depth CS", "Riling Dawnbreaker"]
-  ],
+  [[1, "Common Depth CS", "Riling Dawnbreaker"]],
   [[1, "Booster", "FDN"]],
   [
     [1, "Orb"],


### PR DESCRIPTION
The orb at level 25 is part of the base rewards, not the mastery pass.